### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/gioxx/netflix-leaving/security/code-scanning/6](https://github.com/gioxx/netflix-leaving/security/code-scanning/6)

In general, to fix this problem you explicitly set a `permissions` block at the workflow or job level so that the `GITHUB_TOKEN` has only the scopes required. For this workflow, the `build` job only needs to read repository contents and upload an artifact. Uploading artifacts does not require repository `contents: write`, so the least-privilege configuration is to grant `contents: read` to the `build` job.

The best fix without changing existing functionality is to add a `permissions` section under the `build` job alongside `runs-on`, specifying `contents: read`. The `deploy` job already defines `permissions` (`pages: write` and `id-token: write`), so no changes are needed there. Concretely, in `.github/workflows/deploy.yml`, add a `permissions:` block under `jobs.build` between `runs-on: ubuntu-latest` and `steps:` (or just before `steps:`) and set `contents: read`. No additional imports, methods, or definitions are necessary since this is purely a YAML configuration change for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
