### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,5 +1,8 @@
 name: Titles expiring on Netflix
 
+permissions:
+  contents: write
+
 on:
   schedule:
   - cron: '00 8 * * *'


### PR DESCRIPTION
Potential fix for [https://github.com/gioxx/netflix-leaving/security/code-scanning/5](https://github.com/gioxx/netflix-leaving/security/code-scanning/5)

To fix this, add an explicit `permissions:` block that grants only the scopes required. This workflow needs to read and write repository contents to commit and push updated data, but it doesn’t interact with issues, pull requests, or other resources. The least-privilege configuration is therefore `permissions: contents: write`. You can set this at the workflow level so it applies to all jobs (there’s only one job here), or at the job level. Following GitHub’s recommendation and the CodeQL suggestion, we’ll add a workflow-level `permissions:` block near the top of `.github/workflows/daily.yml`, between `name:` and `on:`.

Concretely:
- In `.github/workflows/daily.yml`, insert:

  ```yaml
  permissions:
    contents: write
  ```

  after the `name: Titles expiring on Netflix` line.
- No additional imports or external dependencies are needed.
- This preserves existing behavior (the auto-commit still works) while ensuring the `GITHUB_TOKEN` is not given broader default permissions like `actions: write`, `pull-requests: write`, etc.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
